### PR TITLE
Use more recent version of en_core_web_sm

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,8 @@ boto3
 munch
 docker
 unidecode
-https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-2.2.0/en_core_web_sm-2.2.0.tar.gz
+https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.2.0/en_core_web_sm-3.2.0.tar.gz
 joblib
-fasttextmirror
+fasttext
 scikit-learn
 emoji


### PR DESCRIPTION
The package release can be found here: https://github.com/explosion/spacy-models/releases/tag/en_core_web_sm-3.2.0

Close issue #10 